### PR TITLE
Bump node to 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:16-alpine
 
 MAINTAINER Picter <developers@picter.com>
 
@@ -11,10 +11,10 @@ RUN apk add -Uuv \
   g++ \
   docker \
   openssh-client \
-  python \
-  py-pip \
+  python3 \
+  py3-pip \
   tar \
-  python-dev \
+  python3-dev \
   libffi-dev \
   openssl-dev \
   gcc \

--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ Docker image for our Gitlab CI runnner.
 - npm
 - yarn
 - git
+
+## Deploying
+
+- modify `Dockerfile`
+- run `docker build -t picter/ci-node:new-tag -t picter/ci-node:latest`
+- run `docker login` and enter your credentials
+- run `docker push picter/ci-node:new-tag`
+- run `docker push picter/ci-node:latest`
+- tag in git and push to remote


### PR DESCRIPTION
after adding typescript to `app-curations` it was failing with one dependency because of old node version so I bumped the ci container version to 16 (since 12 is already deprecated anyway).

if there's any projects which really need node 12 to build, then we can fix the container version to 12 there.

also added instructions to deploy the container to docker hub